### PR TITLE
Adding possibility to specify the name of the file via arguments

### DIFF
--- a/Vic2SaveEditor/src/EditorRunner.java
+++ b/Vic2SaveEditor/src/EditorRunner.java
@@ -2,7 +2,13 @@ import java.util.Scanner;
 
 public class EditorRunner {
 	public static void main(String[] args) {
-		Scanner console = new Scanner(System.in);
+		String param;
+		if (args.length == 0) {
+			param = System.in.toString();
+		} else {
+			param = args[0];
+		}
+		Scanner console = new Scanner(param);
 		SaveFile sf = new SaveFile();
 		String path = console.nextLine();
 		sf.readFile(path);

--- a/Vic2SaveEditor/src/EditorRunner.java
+++ b/Vic2SaveEditor/src/EditorRunner.java
@@ -1,5 +1,7 @@
 import java.util.Scanner;
 
+import savefile.SaveFile;
+
 public class EditorRunner {
 	public static void main(String[] args) {
 		String param;

--- a/Vic2SaveEditor/src/savefile/ContainerNode.java
+++ b/Vic2SaveEditor/src/savefile/ContainerNode.java
@@ -1,0 +1,5 @@
+package savefile;
+
+public class ContainerNode {
+
+}

--- a/Vic2SaveEditor/src/savefile/KeyValueNode.java
+++ b/Vic2SaveEditor/src/savefile/KeyValueNode.java
@@ -1,0 +1,5 @@
+package savefile;
+
+public class KeyValueNode {
+
+}

--- a/Vic2SaveEditor/src/savefile/Node.java
+++ b/Vic2SaveEditor/src/savefile/Node.java
@@ -1,0 +1,9 @@
+package savefile;
+
+/**
+ * A base Node for parsed SaveFile
+ * @author artyom
+ *
+ */
+public class Node {
+}

--- a/Vic2SaveEditor/src/savefile/Parser.java
+++ b/Vic2SaveEditor/src/savefile/Parser.java
@@ -1,0 +1,8 @@
+package savefile;
+
+public class Parser {
+
+	public void parse(SaveFile sf) {
+		
+	}
+}

--- a/Vic2SaveEditor/src/savefile/SaveFile.java
+++ b/Vic2SaveEditor/src/savefile/SaveFile.java
@@ -1,0 +1,35 @@
+package savefile;
+import java.util.ArrayList;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class SaveFile {
+	ArrayList<String> transcribedSaveFile;
+	
+	public SaveFile() {
+	
+	}
+	
+	public void readFile(String path) {
+		transcribedSaveFile = new ArrayList<String>();
+		BufferedReader bfr;
+		try {
+			bfr = new BufferedReader(new FileReader(path)); 				//specify the path to save file
+			String line = bfr.readLine();
+			while (line != null) {
+				transcribedSaveFile.add(line);
+				System.out.println(line);
+				line = bfr.readLine();
+			}
+			bfr.close();
+		} catch(IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public ArrayList<String> getTranscribedSaveFile() {
+		return transcribedSaveFile;
+	}
+}
+

--- a/Vic2SaveEditor/src/savefile/ValuesArrayNode.java
+++ b/Vic2SaveEditor/src/savefile/ValuesArrayNode.java
@@ -1,0 +1,5 @@
+package savefile;
+
+public class ValuesArrayNode {
+
+}


### PR DESCRIPTION
You can specify the path to the file in the arguments and avoid typing it every time. To do it, go to Run -> Run Configuration -> Java Application -> EditorRunner -> Arguments tab on the right side. Put full path to the file into "Program arguments" (e.g.: C:\Save\Russia1835_08_28FinalSave.v2)